### PR TITLE
Feature/check passed value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modbus-utils (1.2.4) stable; urgency=medium
+
+  * added check if any value is passed to write function
+  * improved parsing args for port
+
+ -- Vladimir Romanov <vdromanov@contactless.ru>  Sun, 27 Jan 2018 18:33:12 +0300
+
 modbus-utils (1.2.3) stable; urgency=medium
 
   * disable annoying "timeout is set" information message


### PR DESCRIPTION
Добавил проверку, что modbus_client'у в качестве не именованных аргументов скормили: port (строчка) и value_to_write (int; в случае записывающей функции). Порядок неважен (раньше он принимал первый аргумент за порт, а второй - за данные). Запустили с записывающей функцией, но не указали данные => вываливаемся с ошибкой. Не указали порт - то же самое.

Проверял на wb5(stretch), wb6 и у себя на ноутбуке