### PR TITLE
Fix IP parsinf from forum user cu6apum

### DIFF
--- a/common/mbu-common.h
+++ b/common/mbu-common.h
@@ -14,9 +14,12 @@ typedef enum {
 int getInt(const char str[], int *ok) {
     int value;
     int ret = sscanf(str, "0x%x", &value);
-    if (0 >= ret) {//couldn't convert from hex, try dec
-        ret = sscanf(str, "%d", &value);
-    }
+     if (0 >= ret) {                    // couldn't convert from hex, try dec
+       if (strstr(str, "."))           // dotted ip address
+               ret = 0;
+       else
+               ret = sscanf(str, "%d", &value);
+     }
 
     if (0 != ok) {
         *ok = (0 < ret);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+
+modbus-utils (1.2.5) stable; urgency=medium
+
+  * bugfix
+
+ -- Andrey Radionov <aradionov@contactless.ru>  Mon, 17 May 2021 19:14:12 +0300
+
 modbus-utils (1.2.4) stable; urgency=medium
 
   * added check if any value is passed to write function


### PR DESCRIPTION
Добавил правку от пользователя cu6apum из темы:
https://support.wirenboard.com/t/baga-modbus-tcp-modbus-client/5808/41
Собирается, работает.