### PR TITLE
add Jenkinsfile + bullseye build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildDebSbuild defaultTargets: 'bullseye-armhf'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modbus-utils (1.2.5) stable; urgency=medium
+
+  * rebuild of 1.2.4 for Debian bullseye (without source change)
+  * Makefile: make pkg-config work with multi-arch (for sbuild support)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 29 Jul 2022 18:34:14 +0300
+
 modbus-utils (1.2.4) stable; urgency=medium
 
   * added check if any value is passed to write function

--- a/modbus_client/Makefile
+++ b/modbus_client/Makefile
@@ -8,7 +8,7 @@ else
        CC=$(DEB_HOST_GNU_TYPE)-gcc
 endif
 
-CC_FLAGS=-I../common `pkg-config --libs --cflags libmodbus`
+CC_FLAGS=-I../common `PKG_CONFIG_PATH=/usr/lib/$(DEB_HOST_GNU_TYPE)/pkgconfig pkg-config --libs --cflags libmodbus`
 
 $(BIN_NAME): modbus_client.c
 	$(CC)  modbus_client.c  $(CC_FLAGS)  -o $(BIN_NAME)

--- a/modbus_server/Makefile
+++ b/modbus_server/Makefile
@@ -8,7 +8,7 @@ else
        CC=$(DEB_HOST_GNU_TYPE)-gcc
 endif
 
-CC_FLAGS=-I../common `pkg-config --libs --cflags libmodbus`
+CC_FLAGS=-I../common `PKG_CONFIG_PATH=/usr/lib/$(DEB_HOST_GNU_TYPE)/pkgconfig pkg-config --libs --cflags libmodbus`
 
 $(BIN_NAME):
 	$(CC)  modbus_server.c  $(CC_FLAGS)  -o $(BIN_NAME)


### PR DESCRIPTION
Для корректной работы в bullseye понадобилось пересобрать под немного обновившийся libmodbus (кажется, поломалось ABI).

Вместе с этим добавил Jenkinsfile и починил работу `pkg-config` в Makefile при сборке в sbuild.