### PR TITLE
Fix response timeout option handled incorrectly

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modbus-utils (1.2.6) stable; urgency=medium
+
+  * Fix response timeout option handled incorrectly
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 30 Nov 2022 19:51:00 +0400
+
 modbus-utils (1.2.5) stable; urgency=medium
 
   * rebuild of 1.2.4 for Debian bullseye (without source change)

--- a/modbus_client/modbus_client.c
+++ b/modbus_client/modbus_client.c
@@ -314,8 +314,8 @@ int main(int argc, char **argv)
     modbus_set_slave(ctx, slaveAddr);
 
     struct timeval response_timeout;
-    response_timeout.tv_sec = 0;
-    response_timeout.tv_usec = timeout_ms * 1000;
+    response_timeout.tv_sec = timeout_ms / 1000;
+    response_timeout.tv_usec = (timeout_ms % 1000) * 1000;
     #if LIBMODBUS_VERSION_CHECK(3, 1, 2)
         modbus_set_response_timeout(ctx, response_timeout.tv_sec, response_timeout.tv_usec);
     #else


### PR DESCRIPTION
Debian Bullseye provides libmodbus 3.1.6.

`modbus_set_response_timeout()` changed since 3.0.6 (from Debian Stretch):
https://github.com/stephane/libmodbus/blob/f9fe3b0a5343f7fbb3f5c74196bd0fce88df39d5/src/modbus.c#L1651-L1662
`to_usec` should be <999999.

What's going on under the hood (simplified):
```cpp
#include <sys/time.h>
#include <time.h>
#include <stdio.h>
#include <errno.h>

int main(int argc, char **argv) {
    int timeout_ms;
    sscanf(argv[1], "%d", &timeout_ms);

    struct timeval response_timeout;
#if 1
    response_timeout.tv_sec = 0;
    response_timeout.tv_usec = timeout_ms * 1000;
#else
    response_timeout.tv_sec = timeout_ms / 1000;
    response_timeout.tv_usec = (timeout_ms % 1000) * 1000;
#endif
    printf("%lu sec, %lu usec\n", response_timeout.tv_sec, response_timeout.tv_usec);
    struct timespec request, remaining;
    request.tv_sec = response_timeout.tv_sec;
    request.tv_nsec = ((long int)response_timeout.tv_usec % 1000000) * 1000;
    printf("%lu sec, %lu nsec\n", request.tv_sec, request.tv_nsec);

    while (nanosleep(&request, &remaining) == -1 && errno == EINTR)
        request = remaining;
}
```

Before the fix:
```
$ time ./a.out 800
0 sec, 800000 usec
0 sec, 800000000 nsec

real	0m0.813s
user	0m0.001s
sys	0m0.000s
$ time ./a.out 1000
0 sec, 1000000 usec
0 sec, 0 nsec

real	0m0.002s
user	0m0.001s
sys	0m0.000s
$ time ./a.out 1200
0 sec, 1200000 usec
0 sec, 200000000 nsec

real	0m0.234s
user	0m0.001s
sys	0m0.000s
```

After the fix:
```
$ time ./a.out 800
0 sec, 800000 usec
0 sec, 800000000 nsec

real	0m0.807s
user	0m0.000s
sys	0m0.001s
$ time ./a.out 1000
1 sec, 0 usec
1 sec, 0 nsec

real	0m1.057s
user	0m0.001s
sys	0m0.000s
$ time ./a.out 1200
1 sec, 200000 usec
1 sec, 200000000 nsec

real	0m1.213s
user	0m0.001s
sys	0m0.000s
```