### PR TITLE
fix IP address parse in arguments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modbus-utils (1.2.7) stable; urgency=medium
+
+  * fix IP address parse in arguments
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 12 Jan 2023 21:03:16 +0600
+
 modbus-utils (1.2.6) stable; urgency=medium
 
   * Fix response timeout option handled incorrectly

--- a/modbus_client/modbus_client.c
+++ b/modbus_client/modbus_client.c
@@ -257,7 +257,8 @@ int main(int argc, char **argv)
 
         while (optind < argc) {
 	    raw_data = getInt(argv[optind], &ok);
-            if (0 == hasDevice && ok == 0) { //Portname couldn't consist of only numbers
+            if (0 == hasDevice && (ok == 0 || //Portname couldn't consist of only numbers
+                                   NULL != strchr(argv[optind], '.'))) { // but IP address fits in sscanf()
                 if (0 != backend) {
                     if (Rtu == backend->type) {
                         RtuBackend *rtuP = (RtuBackend*)backend;


### PR DESCRIPTION
Я был уверен, что это в апстриме всё было сломано, но оказывается, это мы сами себя перехитрили в коде, который работает не благодаря, а вопреки:

```console
$ git blame modbus_client/modbus_client.c
...
^ab48531 modbus_client.cpp             (krzys            2013-07-10 03:24:12 +0200 282)         while (optind < argc) {
72a955a4 modbus_client/modbus_client.c (Vladimir Romanov 2019-01-27 12:45:44 +0300 283)             raw_data = getInt(argv[optind], &ok);
72a955a4 modbus_client/modbus_client.c (Vladimir Romanov 2019-01-27 12:45:44 +0300 284)             if (0 == hasDevice && ok == 0) { //Portname couldn't consist of only numbers
^ab48531 modbus_client.cpp             (krzys            2013-07-10 03:24:12 +0200 285)                 if (0 != backend) {
^ab48531 modbus_client.cpp             (krzys            2013-07-10 03:24:12 +0200 286)                     if (Rtu == backend->type) {
c8310819 modbus_client.cpp             (krzys            2013-07-10 03:47:49 +0200 287)                         RtuBackend *rtuP = (RtuBackend*)backend;
...
```

Подправил обратно, чтобы IP-адрес как-то просачивался туда, куда нужно.