### PR TITLE
Fix build with gcc15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modbus-utils (1.3.2) stable; urgency=medium
+
+  * Fix build with gcc15
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Sun, 22 Jun 2025 14:25:00 +0400
+
 modbus-utils (1.3.1) stable; urgency=medium
 
   * Fix lintian

--- a/modbus_client/modbus_client.c
+++ b/modbus_client/modbus_client.c
@@ -117,10 +117,10 @@ int main(int argc, char **argv)
 
         case 'm':
             if (0 == strcmp(optarg, TcpOptVal)) {
-                backend = createTcpBackend((TcpBackend*)malloc(sizeof(TcpBackend)));
+                backend = createTcpBackend();
             }
             else if (0 == strcmp(optarg, RtuOptVal))
-                backend = createRtuBackend((RtuBackend*)malloc(sizeof(RtuBackend)));
+                backend = createRtuBackend();
             else {
                 printf("Unrecognized connection type %s\n\n", optarg);
                 printUsage(argv[0]);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
не собирается с последним gcc 15:
```sh
       > modbus_client.c: In function 'main':
       > modbus_client.c:120:27: error: too many arguments to function 'createTcpBackend'; expected 0, have 1
       >   120 |                 backend = createTcpBackend((TcpBackend*)malloc(sizeof(TcpBackend)));
       >       |                           ^~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > In file included from modbus_client.c:10:
       > ../common/mbu-common.h:209:16: note: declared here
       >   209 | BackendParams *createTcpBackend() {
       >       |                ^~~~~~~~~~~~~~~~
       > modbus_client.c:123:27: error: too many arguments to function 'createRtuBackend'; expected 0, have 1
       >   123 |                 backend = createRtuBackend((RtuBackend*)malloc(sizeof(RtuBackend)));
       >       |                           ^~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > ../common/mbu-common.h:129:16: note: declared here
       >   129 | BackendParams *createRtuBackend() {
       >       |                ^~~~~~~~~~~~~~~~
       > make[1]: *** [Makefile:17: modbus_client] Error 1
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
собрал с gcc15

